### PR TITLE
Print error message instead of panic on unrecognized option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,13 @@ fn handle_cli_arguments() -> CliArgs {
     );
     opts.optflag("h", "help", "print this help menu");
 
-    let matches = opts.parse(&cli_args[1..]).unwrap();
+    let matches = match opts.parse(&cli_args[1..]) {
+        Ok(m) => { m }
+        Err(e) => {
+            eprintln!("{}: {}", program, e.to_string());
+            std::process::exit(1);
+        }
+    };
 
     if matches.opt_present("help") {
         let brief = format!("Usage: {} [options]", program);


### PR DESCRIPTION
Before:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: UnrecognizedOption("version")', src/main.rs:126:46
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    Aborted

After:

    pipr: Unrecognized option: 'version'