### PR TITLE
refactor: fix unholy `use`s of `crate::*`

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1,10 +1,16 @@
-use super::lineeditor::*;
-use super::{
-    command_list_window::CommandListState, key_select_menu::KeySelectMenu, main_window::AutocompleteState, pipr_config::*,
+use crate::{
+    PiprConfig,
+    CmdOutput,
+    CommandExecutionRequest,
+    CommandExecutionHandler
 };
-use crate::command_evaluation::*;
+use crate::app::main_window::AutocompleteState;
+use crate::app::key_select_menu::KeySelectMenu;
+use crate::app::command_list_window::CommandListState;
+use crate::lineeditor::EditorState;
 use crate::commandlist::CommandList;
 use crate::util::VecStringExt;
+
 use crossterm::event::{KeyCode, KeyModifiers};
 
 pub const HELP_TEXT: &str = "\

--- a/src/app/main_window.rs
+++ b/src/app/main_window.rs
@@ -1,8 +1,11 @@
-use super::app::*;
-use super::key_select_menu::KeySelectMenu;
-use super::util::*;
-use super::{lineeditor::*, Path, Stdio};
+use crate::lineeditor::{ EditorEvent, convert_keyevent_to_editorevent };
 use crate::CmdOutput;
+use crate::Stdio;
+use crate::app::key_select_menu::KeySelectMenu;
+use crate::util::{StringExt, VecStringExt};
+use crate::app::app::{App, KeySelectMenuType, CachedCommandPart};
+
+use std::path::Path;
 use crossterm::event::{KeyCode, KeyModifiers};
 use std::path::PathBuf;
 use std::process::Command;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,3 @@
-pub use crate::*;
 extern crate crossterm;
 
 pub mod app;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,13 @@
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate maplit;
-extern crate getopts;
 use atty::Stream;
 use getopts::Options;
 use itertools::Itertools;
 use std::env;
 use std::fs::File;
-use std::io;
-use std::io::Write;
+use std::io::{self, Read, Write};
 use std::path::Path;
-use std::{
-    process::{Command, Stdio},
-    time::Duration,
-};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
 use tokio::stream::StreamExt;
 use tui::{backend::CrosstermBackend, Terminal};
 
@@ -24,22 +17,20 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
-pub mod app;
-pub mod command_evaluation;
-pub mod command_template;
-pub mod commandlist;
-pub mod lineeditor;
-pub mod pipr_config;
-pub mod snippets;
-pub mod ui;
-pub mod util;
+mod app;
+mod command_evaluation;
+mod command_template;
+mod commandlist;
+mod lineeditor;
+mod pipr_config;
+mod snippets;
+mod ui;
+mod util;
 
-pub use app::app::*;
-pub use command_evaluation::*;
-pub use commandlist::CommandList;
-use io::Read;
-pub use lineeditor as le;
-pub use pipr_config::*;
+use app::app::App;
+use command_evaluation::*;
+use commandlist::CommandList;
+use pipr_config::*;
 
 pub struct CliArgs {
     default_content: Option<String>,
@@ -176,6 +167,7 @@ fn after_finish(app: &App, out_file: Option<String>) -> Result<(), failure::Erro
     Ok(())
 }
 
+/// TODO: "Pretty descriptive of a name, I argue" - El Kowar 2022 in Discord:TM: vc
 async fn run_app<W: Write>(mut app: &mut App, mut output_stream: W) -> Result<(), failure::Error> {
     execute!(output_stream, EnterAlternateScreen)?;
     enable_raw_mode()?;

--- a/src/pipr_config.rs
+++ b/src/pipr_config.rs
@@ -4,6 +4,8 @@ use std::io::prelude::*;
 use std::{path::PathBuf, time::Duration};
 
 use super::snippets::*;
+use maplit::hashmap;
+
 use crate::command_template::CommandTemplate;
 
 pub const DEFAULT_CONFIG: &str = "

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use crate::app::command_list_window::CommandListState;
-use crate::app::*;
+use crate::app::app::{App, WindowState};
+
 use ansi_parser::AnsiParser;
 use crossterm::{
     execute,
@@ -23,6 +24,9 @@ use syntect::easy::HighlightLines;
 use syntect::highlighting::{self, Theme, ThemeSet};
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
+
+use itertools::Itertools;
+use lazy_static::lazy_static;
 
 lazy_static! {
     static ref THEME_SET: ThemeSet = ThemeSet::load_defaults();
@@ -86,7 +90,7 @@ pub fn draw_app<B: Backend>(terminal: &mut Terminal<B>, mut app: &mut App) -> Re
                     let options = opened_key_select_menu
                         .option_list_strings()
                         .map(|opt| ListItem::new(Span::raw(opt)))
-                        .collect_vec();
+                        .collect::<Vec<_>>();
 
                     f.render_widget(List::new(options).block(make_default_block("Open in", false)), root_chunks[0]);
                 }
@@ -104,7 +108,7 @@ pub fn draw_app<B: Backend>(terminal: &mut Terminal<B>, mut app: &mut App) -> Re
                             .options
                             .iter()
                             .map(|x| ListItem::new(x.as_str()))
-                            .collect_vec(),
+                            .collect::<Vec<_>>(),
                     )
                     .highlight_style(Style::default().fg(Color::Black).bg(Color::White))
                     .block(make_default_block("Suggestions", false));
@@ -161,7 +165,7 @@ fn draw_command_list<B: Backend>(f: &mut Frame<B>, rect: Rect, always_show_previ
         .iter()
         .map(|entry| entry.as_string().replace("\n", " ↵ "))
         .map(|entry| ListItem::new(Span::raw(entry)))
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     let mut list_state = ListState::default();
     list_state.select(state.selected_idx);


### PR DESCRIPTION
alternative names:
- "fix circumventing rust's module system"
- "remove `pub use` in `main.rs`"

In retrospect an interesting crutch for any beginner rustacean. Also fixes use order for `crate` to come first.